### PR TITLE
Fix checkdb and external ssl configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -x; \
         gettext \
         ca-certificates \
         nginx \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/checkdb.py
+++ b/checkdb.py
@@ -34,7 +34,7 @@ while True:
         exists = False
     if exists is False:
         tryCount += 1
-        if tryCount < DB_TIMEOUT:
+        if tryCount < int(DB_TIMEOUT):
             # uncomment this line for debugging
             # print("Database is not yet ready. Connection attempt " + str(tryCount) + " of " + str(DB_TIMEOUT) + ". Sleeping for " + str(sleepSeconds) + " seconds and trying again.\n")
             time.sleep(sleepSeconds)
@@ -42,5 +42,13 @@ while True:
             print("Database wait timeout reached. Exiting.")
             sys.exit(1)
     else:
-        print("Database is ready.")
-        sys.exit(0)
+        # check if there is content in the database
+        cur = conn.cursor()
+        cur.execute("select * from information_schema.tables where table_name=%s", ('django_migrations',))
+        exists = bool(cur.rowcount)
+        if exists is False:
+            print("Database does not appear to be setup.")
+            sys.exit(2)
+        else:
+            print("Database is ready.")
+            sys.exit(0)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,8 +48,8 @@ elif grep -q "wss://" "/taiga/conf.json"; then
 fi
 
 # Reinitialize nginx links
+rm /etc/nginx/sites-enabled/*
 if [ "$TAIGA_SSL" = "True" ]; then
-  rm /etc/nginx/sites-enabled/*
   if [ ! -z "$RABBIT_PORT_5672_TCP_ADDR" ]; then
     ln -s /etc/nginx/sites-available/taiga-ssl /etc/nginx/sites-enabled/taiga-events-ssl
   else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,8 +48,8 @@ elif grep -q "wss://" "/taiga/conf.json"; then
 fi
 
 # Reinitialize nginx links
-rm /etc/nginx/sites-enabled/*
-if [ "$TAIGA_SSL_BY_REVERSE_PROXY" = "True" ] || [ "$TAIGA_SSL" = "True" ]; then
+if [ "$TAIGA_SSL" = "True" ]; then
+  rm /etc/nginx/sites-enabled/*
   if [ ! -z "$RABBIT_PORT_5672_TCP_ADDR" ]; then
     ln -s /etc/nginx/sites-available/taiga-ssl /etc/nginx/sites-enabled/taiga-events-ssl
   else


### PR DESCRIPTION
This PR fixes the following issues:
- `docker-entrypoint.sh` checks for `checkdb.py` return value 2, however `checkdb.py` never returns 2. Thus, I check in `checkdb.py` if an initial db exists
- `docker-entrypoint.sh` actually copies the nginx ssl file into the container. However, when using an external ssl-reverse-proxy, `nginx` *inside* the container must not be adapted. IMHO: that is the point of using an external ssl-reverse proxy 
PS: If you agree with this PR; we should create a valid and working *tag* to indicate the working version and maybe clean up the old *non-working* tags?